### PR TITLE
Add session mock to blaze

### DIFF
--- a/blazeRenderer/renderBlaze.js
+++ b/blazeRenderer/renderBlaze.js
@@ -71,7 +71,7 @@ const renderBlazeWithTemplates = function (templateName, parsedTemplates) {
     if (Array.from(arguments)[1] ) {
       passedArguments = Array.from(arguments)[1]['hash']  ? Array.from(arguments)[1]['hash'] : {_myOwnData: Array.from(arguments)[1]}
     }
-        Template[templateName].helpers = Object.assign({}, Template[templateName].getHelpers(), passedArguments, {isInRole: function() { return true }}, {$or: function(arg1, arg2) { return arg1 || arg2}}, {$gt: function(arg1, arg2) { return arg1 > arg2}}, {$eq: function(arg1, arg2) { return arg1 === arg2 }}, {$exists: function(arg1) { return !!arg1 }}, {pathFor: function(arg1, arg2) { return `${arg1}/${arg2}`}}, {_myOwnThis: function() {return this._myOwnData}})
+        Template[templateName].helpers = Object.assign({}, Template[templateName].getHelpers(), passedArguments, {isInRole: function() { return true }}, {$or: function(arg1, arg2) { return arg1 || arg2}}, {$gt: function(arg1, arg2) { return arg1 > arg2}}, {$eq: function(arg1, arg2) { return arg1 === arg2 }}, {$exists: function(arg1) { return !!arg1 }}, {pathFor: function(arg1, arg2) { return `${arg1}/${arg2}`}}, {_myOwnThis: function() {return this._myOwnData}}, {$:{Session:{get: function(arg) { return true }}}})
 
       //TODO add test for isInRole, and most probably make this configurable instead of hardcoded.
       // Used in https://github.com/alanning/meteor-roles

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "main": "lib/renderBlaze.js",
   "dependencies": {
-    "babel-cli": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "glob": "^7.1.2"
   },
@@ -22,7 +21,8 @@
     "babel-preset-es2015-without-strict": "0.0.4",
     "jest-blaze-html": "^1.0.1",
     "js-beautify": "^1.6.14",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "babel-cli": "^6.26.0"
   },
   "keywords": [
     "meteor",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "main": "lib/renderBlaze.js",
   "dependencies": {
+    "babel-cli": "^6.26.0",
     "cheerio": "^1.0.0-rc.2",
     "glob": "^7.1.2"
   },


### PR DESCRIPTION
Added:
```
{$:{Session:{get: function(arg) { return true }}}}
```
+ babel-cli to dev-deps (you probably have it globally)

