### PR TITLE
Add test for failing content blocks

### DIFF
--- a/imports/client/lib/TwoContentBlocks.html
+++ b/imports/client/lib/TwoContentBlocks.html
@@ -1,0 +1,18 @@
+<template name="wrapper">
+    {{#table param='paramForTable'}}
+        <span>Inside table</span>
+    {{/table}}
+    {{#modal param='paramForModal'}}
+        <span>Inside modal</span>
+    {{/modal}}
+</template>
+
+<template name="table">
+    <span class="passedParamTable">{{param}}</span>
+    {{> Template.contentBlock }}
+</template>
+
+<template name="modal">
+    <span class="passedParamModal">{{param}}</span>
+    {{> Template.contentBlock }}
+</template>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "babel blazeRenderer --out-dir lib --source-maps",
     "watch": "npm run build -- --watch",
     "test": "jest",
-    "jest-html": "jest-html"
+    "jest-html": "jest-html",
+    "test:watch": "jest --watch"
   },
   "main": "lib/renderBlaze.js",
   "dependencies": {

--- a/tests/__snapshots__/template.test.js.snap
+++ b/tests/__snapshots__/template.test.js.snap
@@ -243,6 +243,28 @@ Array [
     "templateName": "templateWithContentBlockInside",
   },
   Object {
+    "cheerio": "{{#table param='paramForTable'}}
+        <span>Inside table</span>
+    {{/table}}
+    {{#modal param='paramForModal'}}
+        <span>Inside modal</span>
+    {{/modal}}",
+    "templateFile": "imports/client/lib/TwoContentBlocks.html",
+    "templateName": "wrapper",
+  },
+  Object {
+    "cheerio": "<span class=\\"passedParamTable\\">{{param}}</span>
+    {{ Template.contentBlock }}",
+    "templateFile": "imports/client/lib/TwoContentBlocks.html",
+    "templateName": "table",
+  },
+  Object {
+    "cheerio": "<span class=\\"passedParamModal\\">{{param}}</span>
+    {{ Template.contentBlock }}",
+    "templateFile": "imports/client/lib/TwoContentBlocks.html",
+    "templateName": "modal",
+  },
+  Object {
     "cheerio": "<div>
         outside with
         {{#with myBeautifulObject}}

--- a/tests/twoContentBlocks.test.js
+++ b/tests/twoContentBlocks.test.js
@@ -1,0 +1,9 @@
+import renderBlaze, { renderBlazeWithData, parseTemplates } from '../blazeRenderer/renderBlaze';
+
+describe('TwoContentBlocks', function () {
+  describe('templates', function () {
+    it('should be able to render two or more templates with contentBlock inside', function () {
+      expect(renderBlaze('wrapper')).toMatchSnapshot()
+    })
+  })
+})


### PR DESCRIPTION
Added test fails with:

```
TypeError: Cannot read property 'bind' of undefined

      at Object.<anonymous>.BlazeMine.View._render (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:143:65)
      at node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1233:17
      at Object.<anonymous>.BlazeMine._withCurrentView (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1328:12)
      at Object.<anonymous>.BlazeMine._expandView (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1232:26)
      at HTMLVisitorSubtype.visitObject (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1249:55)
      at HTMLVisitorSubtype.visit (node_modules/blaze-renderer/lib/blazeInternals/html.js:307:31)
      at Object.<anonymous>.BlazeMine._expand (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1279:68)
      at Object.<anonymous>.BlazeMine._expandView (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1237:26)
      at HTMLVisitorSubtype.visitObject (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1249:55)
      at HTMLVisitorSubtype.visit (node_modules/blaze-renderer/lib/blazeInternals/html.js:307:31)
      at HTMLVisitorSubtype.visitArray (node_modules/blaze-renderer/lib/blazeInternals/html.js:341:32)
      at HTMLVisitorSubtype.visitChildren (node_modules/blaze-renderer/lib/blazeInternals/html.js:372:28)
      at HTMLVisitorSubtype.visitTag (node_modules/blaze-renderer/lib/blazeInternals/html.js:359:42)
      at HTMLVisitorSubtype.visit (node_modules/blaze-renderer/lib/blazeInternals/html.js:293:34)
      at HTMLVisitorSubtype.visitArray (node_modules/blaze-renderer/lib/blazeInternals/html.js:341:32)
      at HTMLVisitorSubtype.visit (node_modules/blaze-renderer/lib/blazeInternals/html.js:305:61)
      at Object.<anonymous>.BlazeMine._expand (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1279:68)
      at Object.<anonymous>.BlazeMine._expandView (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1237:26)
      at Object.<anonymous>.BlazeMine.toHTML (node_modules/blaze-renderer/lib/blazeInternals/blazeWith.js:1477:36)
      at toHTML (node_modules/blaze-renderer/lib/renderBlaze.js:47:20)
      at includeReplacement (node_modules/blaze-renderer/lib/renderBlaze.js:153:12)
      at renderBlazeWithTemplates (node_modules/blaze-renderer/lib/renderBlaze.js:155:32)```