### PR TITLE
add test case for isMultiple situation in filters

### DIFF
--- a/imports/client/lib/multipleFlagTest.html
+++ b/imports/client/lib/multipleFlagTest.html
@@ -1,0 +1,9 @@
+<template name='renderMultipleSelect'>
+    <select {{isMultiple}}>
+        <option value="testMultiple">testMultiple</option>
+    </select>
+</template>
+
+<template name="testMultpile">
+    {{>renderMultipleSelect isMultiple=true}}
+</template>

--- a/imports/client/lib/multipleFlagTest.html
+++ b/imports/client/lib/multipleFlagTest.html
@@ -4,6 +4,6 @@
     </select>
 </template>
 
-<template name="testMultpile">
+<template name="testMultiple">
     {{>renderMultipleSelect isMultiple=true}}
 </template>

--- a/tests/__snapshots__/template.test.js.snap
+++ b/tests/__snapshots__/template.test.js.snap
@@ -156,6 +156,18 @@ Array [
     "templateName": "colorRow",
   },
   Object {
+    "cheerio": "<select {{isMultiple}}>
+        <option value=\\"testMultiple\\">testMultiple</option>
+    </select>",
+    "templateFile": "imports/client/lib/multipleFlagTest.html",
+    "templateName": "renderMultipleSelect",
+  },
+  Object {
+    "cheerio": "{{{ includeReplacement 'renderMultipleSelect'  isMultiple=true }}}",
+    "templateFile": "imports/client/lib/multipleFlagTest.html",
+    "templateName": "testMultpile",
+  },
+  Object {
     "cheerio": "<div>Parent: {{{ includeReplacement 'nestedWithParams'  param=hello test=\\"not hello\\" }}}</div>
     {{#each returnObject}}
     <div>Parent with object params: {{{ includeReplacement 'anotherNestedWithObjectParam'  thing.inside.object }}}</div>

--- a/tests/renderMultipleSelect.js
+++ b/tests/renderMultipleSelect.js
@@ -1,0 +1,3 @@
+Template.renderMultipleSelect.helpers({
+  isMultiple: () => this.isMultiple ? 'multiple' : '',
+})

--- a/tests/template.test.js
+++ b/tests/template.test.js
@@ -86,7 +86,7 @@ it('template renders contentBlock in right order', () => {
 
 it('should execute helper function inside template when calling {{helperName}} not a passed parameter that has the same name - {{helperName}}', () => {
   require('./renderMultipleSelect')
-  expect(renderBlaze('renderMultipleSelect')).toMatchSnapshot()
+  expect(renderBlaze('testMultiple')).toMatchSnapshot()
 })
 //TODO need a test for skipping the each on undefined.
 

--- a/tests/template.test.js
+++ b/tests/template.test.js
@@ -83,6 +83,11 @@ it('template renders contentBlock in right order', () => {
   require('./toTable')
   expect(renderBlaze('toTable')).toMatchSnapshot()
 })
+
+it('should execute helper function inside template when calling {{helperName}} not a passed parameter that has the same name - {{helperName}}', () => {
+  require('./renderMultipleSelect')
+  expect(renderBlaze('renderMultipleSelect')).toMatchSnapshot()
+})
 //TODO need a test for skipping the each on undefined.
 
 //TODO need a test for helper with a value of undefined


### PR DESCRIPTION
Throws error because it wants to display <true> inside select, instead of 'multiple' or '' if it took it from helpers
```
Expected valid attribute name, '', null, or object
      
      at Object.<anonymous>.SpacebarsMine.attrMustache (blazeRenderer/blazeInternals/compiler.js:2803:11)
      at eval (eval at toHTML (blazeRenderer/renderBlaze.js:23:12), <anonymous>:1:106)
      at Object.<anonymous>.BlazeMine._withCurrentView (blazeRenderer/blazeInternals/blazeWith.js:1372:12)
      at HTMLVisitorSubtype.visitAttributes (blazeRenderer/blazeInternals/blazeWith.js:1291:23)
      at HTMLVisitorSubtype.visitTag (blazeRenderer/blazeInternals/html.js:398:41)
      at HTMLVisitorSubtype.visit (blazeRenderer/blazeInternals/html.js:321:34)
      at Object.<anonymous>.BlazeMine._expand (blazeRenderer/blazeInternals/blazeWith.js:1317:31)
      at Object.<anonymous>.BlazeMine._expandView (blazeRenderer/blazeInternals/blazeWith.js:1269:26)
      at Object.<anonymous>.BlazeMine.toHTML (blazeRenderer/blazeInternals/blazeWith.js:1533:36)
      at toHTML (blazeRenderer/renderBlaze.js:24:20)
      at Object.includeReplacement (blazeRenderer/renderBlaze.js:113:12)
      at blazeRenderer/blazeInternals/blazeWith.js:323:14
      at Object.<anonymous>.SpacebarsMine.call (blazeRenderer/blazeInternals/compiler.js:2842:18)
      at Object.<anonymous>.SpacebarsMine.mustacheImpl (blazeRenderer/blazeInternals/compiler.js:2776:29)
      at Object.<anonymous>.SpacebarsMine.mustache (blazeRenderer/blazeInternals/compiler.js:2780:43)
      at Object.<anonymous>.BlazeMine.View.eval [as _render] (eval at toHTML (blazeRenderer/renderBlaze.js:23:12), <anonymous>:1:141)
      at blazeRenderer/blazeInternals/blazeWith.js:1265:17
      at Object.<anonymous>.BlazeMine._withCurrentView (blazeRenderer/blazeInternals/blazeWith.js:1372:12)
      at Object.<anonymous>.BlazeMine._expandView (blazeRenderer/blazeInternals/blazeWith.js:1264:26)
      at HTMLVisitorSubtype.visitObject (blazeRenderer/blazeInternals/blazeWith.js:1283:22)
      at HTMLVisitorSubtype.visit (blazeRenderer/blazeInternals/html.js:336:31)
      at Object.<anonymous>.BlazeMine._expand (blazeRenderer/blazeInternals/blazeWith.js:1317:31)
      at Object.<anonymous>.BlazeMine._expandView (blazeRenderer/blazeInternals/blazeWith.js:1269:26)
      at Object.<anonymous>.BlazeMine.toHTML (blazeRenderer/blazeInternals/blazeWith.js:1533:36)
      at toHTML (blazeRenderer/renderBlaze.js:24:20)
      at includeReplacement (blazeRenderer/renderBlaze.js:113:12)
      at renderBlazeWithTemplates (blazeRenderer/renderBlaze.js:115:32)
      at Object.<anonymous> (tests/template.test.js:89:36)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

```